### PR TITLE
Add multi-language support to ASP.NET MVC Core

### DIFF
--- a/Controllers/AyarlarController.cs
+++ b/Controllers/AyarlarController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using dafsem.Context;
 using dafsem.Models;
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using dafsem.Services.Contracts;
 using Microsoft.Extensions.Localization;
 using dafsem.Resources;
+using Microsoft.AspNetCore.Localization;
 
 namespace dafsem.Controllers
 {
@@ -40,11 +41,12 @@ namespace dafsem.Controllers
             if (!string.IsNullOrEmpty(panelLanguage))
             {
                 // Cookie'yi doğru formatta oluştur (ASP.NET Core localization standardına uygun)
-                var cookieValue = $"c={panelLanguage}|uic={panelLanguage}";
+                var cookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(panelLanguage));
 
                 CookieOptions option = new CookieOptions
                 {
-                    Expires = DateTime.Now.AddYears(1),
+                    Path = "/",
+                    Expires = DateTimeOffset.UtcNow.AddYears(1),
                     HttpOnly = true,
                     SameSite = SameSiteMode.Lax
                 };

--- a/Views/Ayarlar/Index.cshtml
+++ b/Views/Ayarlar/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@model dafsem.Models.Ayarlar
+@model dafsem.Models.Ayarlar
 @inject IStringLocalizer<SharedResource> Localizer
 
 @{
@@ -164,34 +164,28 @@
         <form asp-action="ChangePanelLanguage" method="post" class="panel-language-form">
             @Html.AntiForgeryToken()
             @{
-                // Cookie'den dil bilgisini doğru şekilde al
-                var panelLanguageCookie = Context.Request.Cookies["PanelLanguage"];
-                var currentLanguage = "tr-TR"; // Varsayılan dil
-
-                if (!string.IsNullOrEmpty(panelLanguageCookie))
+                // Mevcut UI kültür adını kullan (örn. "tr-TR")
+                var currentLanguage = System.Globalization.CultureInfo.CurrentUICulture.Name;
+                var languages = new[]
                 {
-                    // ASP.NET Core localization cookie formatı: c=tr-TR|uic=tr-TR
-                    if (panelLanguageCookie.Contains("|"))
-                    {
-                        var parts = panelLanguageCookie.Split('|');
-                        var culturePart = parts.FirstOrDefault(p => p.StartsWith("c="));
-                        if (!string.IsNullOrEmpty(culturePart))
-                        {
-                            currentLanguage = culturePart.Substring(2);
-                        }
-                    }
-                    else
-                    {
-                        // Eski format için backward compatibility
-                        currentLanguage = panelLanguageCookie;
-                    }
-                }
+                    new { Value = "tr-TR", Text = Localizer["Turkish"].Value },
+                    new { Value = "en-US", Text = Localizer["English"].Value },
+                    new { Value = "ar-SA", Text = Localizer["Arabic"].Value }
+                };
             }
             <select name="panelLanguage" class="panel-language-select" required>
                 <option value="">@Localizer["SelectLanguage"]</option>
-                <option value="tr-TR" selected="@(currentLanguage == "tr-TR")">@Localizer["Turkish"]</option>
-                <option value="en-US" selected="@(currentLanguage == "en-US")">@Localizer["English"]</option>
-                <option value="ar-SA" selected="@(currentLanguage == "ar-SA")">@Localizer["Arabic"]</option>
+                @foreach (var lang in languages)
+                {
+                    if (string.Equals(currentLanguage, lang.Value, System.StringComparison.OrdinalIgnoreCase))
+                    {
+                        <option value="@lang.Value" selected>@lang.Text</option>
+                    }
+                    else
+                    {
+                        <option value="@lang.Value">@lang.Text</option>
+                    }
+                }
             </select>
             <button type="submit" class="panel-language-btn">
                 <i class="bi bi-check-circle me-2"></i>@Localizer["ChangeLanguage"]


### PR DESCRIPTION
Implement ASP.NET Core MVC localization by standardizing culture cookie handling and view language selection.

The existing localization setup had issues with the `ChangePanelLanguage` action not setting the localization cookie in the standard ASP.NET Core format or with the correct path, and the `Index.cshtml` view incorrectly determining the current language. This PR corrects these to ensure consistent and functional multi-language support.

---
<a href="https://cursor.com/background-agent?bcId=bc-aabdf6e5-06aa-4e16-a9ba-e6d356175599">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aabdf6e5-06aa-4e16-a9ba-e6d356175599">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

